### PR TITLE
Add camera service for plant deck automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Plant Deck
 
 Smart Plant Monitoring and Automation System.
+
+## Camera Service
+
+The `camera_service` captures images using OpenCV and analyzes foliage health. Based on the analysis it sends commands to the actuator service to adjust watering automatically.

--- a/software/services/camera_service/README.md
+++ b/software/services/camera_service/README.md
@@ -1,0 +1,3 @@
+# camera_service
+
+This service captures images from a camera connected to the Plant Deck. Using OpenCV it analyzes the plant's foliage and sends commands to actuators when adjustments are needed.

--- a/software/services/camera_service/camera_analysis.py
+++ b/software/services/camera_service/camera_analysis.py
@@ -1,0 +1,58 @@
+import time
+from dataclasses import dataclass
+
+import cv2
+import numpy as np
+import requests
+
+
+@dataclass
+class PlantMonitorConfig:
+    camera_index: int = 0
+    actuator_url: str = "http://localhost:5000/api/actuators"
+    check_interval: float = 5.0  # seconds
+
+
+def analyze_green_ratio(frame: np.ndarray) -> float:
+    """Return ratio of green pixels in the frame."""
+    hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+    lower_green = np.array([35, 40, 40])
+    upper_green = np.array([85, 255, 255])
+    mask = cv2.inRange(hsv, lower_green, upper_green)
+    return float(np.sum(mask)) / (mask.size * 255)
+
+
+def send_actuator_command(url: str, action: str) -> None:
+    try:
+        requests.post(url, json={"action": action}, timeout=2)
+    except requests.RequestException:
+        print("Failed to send command", action)
+
+
+class PlantMonitor:
+    def __init__(self, config: PlantMonitorConfig | None = None) -> None:
+        self.config = config or PlantMonitorConfig()
+        self.cap = cv2.VideoCapture(self.config.camera_index)
+        if not self.cap.isOpened():
+            raise RuntimeError("Camera could not be opened")
+
+    def step(self) -> None:
+        ret, frame = self.cap.read()
+        if not ret:
+            raise RuntimeError("Failed to capture frame")
+        ratio = analyze_green_ratio(frame)
+        action = "water_on" if ratio < 0.1 else "water_off"
+        send_actuator_command(self.config.actuator_url, action)
+
+    def run(self) -> None:
+        try:
+            while True:
+                self.step()
+                time.sleep(self.config.check_interval)
+        finally:
+            self.cap.release()
+
+
+if __name__ == "__main__":
+    monitor = PlantMonitor()
+    monitor.run()


### PR DESCRIPTION
## Summary
- document camera service in README
- add camera_service with OpenCV-based monitoring and actuator control

## Testing
- `pip install opencv-python-headless`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0133bd4c832884ae00418bab5699