### PR TITLE
Add plant ID and automation services

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ Smart Plant Monitoring and Automation System.
 ## Camera Service
 
 The `camera_service` captures images using OpenCV and analyzes foliage health. Based on the analysis it sends commands to the actuator service to adjust watering automatically.
+
+## Plant Identifier Service
+
+The `plant_identifier_service` uses the online Plant.id API to identify plant species from captured images. Set the `PLANT_ID_API_KEY` environment variable to use this service.
+
+## Automation Service
+
+The `automation_service` coordinates sensors, plant identification, and actuators to maintain optimal conditions.

--- a/software/services/automation_service/README.md
+++ b/software/services/automation_service/README.md
@@ -1,0 +1,3 @@
+# automation_service
+
+Coordinates sensors, actuators, and plant identification results to automate plant care.

--- a/software/services/automation_service/automation.py
+++ b/software/services/automation_service/automation.py
@@ -1,0 +1,60 @@
+"""Simple automation controller for Plant Deck."""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import requests
+
+from software.services.plant_identifier_service.plant_identifier import PlantIdentifier
+
+
+@dataclass
+class AutomationConfig:
+    sensor_url: str = "http://localhost:5000/api/sensors"
+    actuator_url: str = "http://localhost:5000/api/actuators"
+    camera_image: str = "snapshot.jpg"
+    check_interval: float = 10.0
+
+
+class AutomationController:
+    def __init__(self, config: AutomationConfig | None = None) -> None:
+        self.config = config or AutomationConfig()
+        self.identifier = PlantIdentifier()
+
+    def read_sensors(self) -> dict:
+        try:
+            response = requests.get(self.config.sensor_url, timeout=2)
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException:
+            return {}
+
+    def send_actuator(self, action: str) -> None:
+        try:
+            requests.post(self.config.actuator_url, json={"action": action}, timeout=2)
+        except requests.RequestException:
+            print("Failed to send command", action)
+
+    def step(self) -> None:
+        sensors = self.read_sensors()
+        moisture = sensors.get("moisture", 1.0)
+        if moisture < 0.3:
+            self.send_actuator("water_on")
+        else:
+            self.send_actuator("water_off")
+
+        try:
+            plant_names = self.identifier.identify(self.config.camera_image)
+            print("Identified plant:", ", ".join(plant_names))
+        except Exception as e:  # broad except ok for script
+            print("Identification failed:", e)
+
+    def run(self) -> None:
+        while True:
+            self.step()
+            time.sleep(self.config.check_interval)
+
+
+if __name__ == "__main__":
+    AutomationController().run()

--- a/software/services/plant_identifier_service/README.md
+++ b/software/services/plant_identifier_service/README.md
@@ -1,0 +1,3 @@
+# plant_identifier_service
+
+This service identifies plant species by sending captured images to the Plant.id API. The API key should be provided via the `PLANT_ID_API_KEY` environment variable.

--- a/software/services/plant_identifier_service/plant_identifier.py
+++ b/software/services/plant_identifier_service/plant_identifier.py
@@ -1,0 +1,48 @@
+"""Identify plants using the Plant.id API."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import List
+
+import requests
+
+
+@dataclass
+class PlantIdentifierConfig:
+    api_key: str | None = None
+    api_url: str = "https://api.plant.id/v2/identify"
+
+
+class PlantIdentifier:
+    """Client for the Plant.id identification API."""
+
+    def __init__(self, config: PlantIdentifierConfig | None = None) -> None:
+        self.config = config or PlantIdentifierConfig()
+        if not self.config.api_key:
+            self.config.api_key = os.environ.get("PLANT_ID_API_KEY", "")
+        if not self.config.api_key:
+            raise RuntimeError("PLANT_ID_API_KEY not provided")
+
+    def identify(self, image_path: str) -> List[str]:
+        """Return a list of probable plant names given an image path."""
+        with open(image_path, "rb") as f:
+            files = {"images": f}
+            headers = {"Api-Key": self.config.api_key}
+            response = requests.post(self.config.api_url, files=files, headers=headers, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        suggestions = data.get("suggestions", [])
+        names = [s.get("plant_name", "") for s in suggestions]
+        return names
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: python plant_identifier.py <image_path>")
+        raise SystemExit(1)
+    pid = PlantIdentifier()
+    result = pid.identify(sys.argv[1])
+    print("\n".join(result))

--- a/tests/unit/test_plant_identifier.py
+++ b/tests/unit/test_plant_identifier.py
@@ -1,0 +1,21 @@
+import builtins
+from unittest import mock
+
+import pytest
+
+from software.services.plant_identifier_service.plant_identifier import PlantIdentifier, PlantIdentifierConfig
+
+
+def test_identify_makes_request(tmp_path):
+    img = tmp_path / "img.jpg"
+    img.write_bytes(b"test")
+
+    response_data = {"suggestions": [{"plant_name": "Rose"}]}
+    with mock.patch("requests.post") as post:
+        post.return_value.json.return_value = response_data
+        post.return_value.raise_for_status.return_value = None
+        identifier = PlantIdentifier(PlantIdentifierConfig(api_key="k"))
+        names = identifier.identify(str(img))
+
+    assert names == ["Rose"]
+    assert post.called


### PR DESCRIPTION
## Summary
- support plant identification with the Plant.id API
- add an automation controller that integrates sensors and identification
- document new services in the README
- test the plant identifier client

## Testing
- `python3 -m pytest tests/unit/test_plant_identifier.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684f14fa0cb08328b403ab37f6effb3e