### PR TITLE
Add web inference pipeline with React and TensorFlow.js

### DIFF
--- a/web/__tests__/infer.test.js
+++ b/web/__tests__/infer.test.js
@@ -1,0 +1,31 @@
+global.self = { location: { origin: '' } };
+
+jest.mock('@tensorflow/tfjs', () => ({}));
+jest.mock('@tensorflow/tfjs-tflite', () => ({
+  loadTFLiteModel: jest.fn(() => Promise.resolve({ predict: jest.fn(() => [ {arraySync:()=>[]}, {arraySync:()=>[]} ]) }))
+}));
+
+jest.mock('../src/preprocess.js');
+jest.mock('../src/detect.js');
+jest.mock('../src/classify.js');
+jest.mock('../src/saliency.js');
+
+const { runInference } = require('../src/infer.js');
+const { preprocess } = require('../src/preprocess.js');
+const { detect } = require('../src/detect.js');
+const { classify } = require('../src/classify.js');
+const { gradCAM } = require('../src/saliency.js');
+
+test('runInference aggregates module results', async () => {
+  preprocess.mockReturnValue('input');
+  detect.mockResolvedValue([{ box: [0,0,1,1], score: 0.9 }]);
+  classify.mockResolvedValue({ label: 1, score: 0.8 });
+  gradCAM.mockResolvedValue('heatmap');
+
+  const img = {};
+  const res = await runInference(img);
+
+  expect(res.detections).toHaveLength(1);
+  expect(res.cls.label).toBe(1);
+  expect(res.heatmap).toBe('heatmap');
+});

--- a/web/models/README.md
+++ b/web/models/README.md
@@ -1,0 +1,3 @@
+Pretrained models should be placed in this directory:
+- mobilenetv2_bgrem.tflite
+- yolov8_disease.tflite

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "plant-ai-web",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "@tensorflow/tfjs": "^4.10.0",
+    "@tensorflow/tfjs-tflite": "^0.0.1-alpha.10"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,0 +1,45 @@
+import React, { useRef, useState } from 'react';
+import { runInference } from './infer.js';
+
+export default function App() {
+  const imgRef = useRef(null);
+  const canvasRef = useRef(null);
+  const [result, setResult] = useState(null);
+
+  const handleFile = e => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const url = URL.createObjectURL(file);
+    imgRef.current.src = url;
+  };
+
+  const onLoad = async () => {
+    const res = await runInference(imgRef.current);
+    setResult(res);
+    const ctx = canvasRef.current.getContext('2d');
+    ctx.drawImage(imgRef.current, 0, 0);
+    res.detections.forEach(d => {
+      const [x1, y1, x2, y2] = d.box;
+      ctx.strokeStyle = 'red';
+      ctx.lineWidth = 2;
+      ctx.strokeRect(x1, y1, x2 - x1, y2 - y1);
+    });
+    // Overlay heatmap (simple alpha composite)
+    const heatmap = res.heatmap.arraySync();
+    // naive overlay for demo
+    // ...
+  };
+
+  return (
+    <div>
+      <input type="file" accept="image/*" onChange={handleFile} />
+      <canvas ref={canvasRef} width={224} height={224} />
+      <img ref={imgRef} onLoad={onLoad} alt="" style={{ display: 'none' }} />
+      {result && (
+        <div>
+          Prediction: {result.cls.label} ({(result.cls.score * 100).toFixed(1)}%)
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/classify.js
+++ b/web/src/classify.js
@@ -1,0 +1,21 @@
+const tflite = require('@tensorflow/tfjs-tflite');
+const tf = require('@tensorflow/tfjs');
+
+let classifier;
+
+async function loadClassifier() {
+  if (!classifier) {
+    classifier = await tflite.loadTFLiteModel('/models/mobilenetv2_bgrem.tflite');
+  }
+  return classifier;
+}
+
+async function classify(input) {
+  const model = await loadClassifier();
+  const logits = model.predict(input);
+  const label = tf.argMax(logits, 1).dataSync()[0];
+  const score = tf.max(logits, 1).dataSync()[0];
+  return { label, score };
+}
+
+module.exports = { loadClassifier, classify };

--- a/web/src/detect.js
+++ b/web/src/detect.js
@@ -1,0 +1,50 @@
+const tflite = require('@tensorflow/tfjs-tflite');
+const tf = require('@tensorflow/tfjs');
+
+let detector;
+
+async function loadDetector() {
+  if (!detector) {
+    detector = await tflite.loadTFLiteModel('/models/yolov8_disease.tflite');
+  }
+  return detector;
+}
+
+function nms(boxes, scores, iouThreshold = 0.5) {
+  const selected = [];
+  let idxs = scores.map((s, i) => [s, i]).sort((a, b) => b[0] - a[0]);
+  while (idxs.length) {
+    const [, idx] = idxs.shift();
+    selected.push(idx);
+    idxs = idxs.filter(([s, i]) => {
+      const iou = boxIou(boxes[idx], boxes[i]);
+      return iou < iouThreshold;
+    });
+  }
+  return selected;
+}
+
+function boxIou(a, b) {
+  const [ax1, ay1, ax2, ay2] = a;
+  const [bx1, by1, bx2, by2] = b;
+  const areaA = Math.max(0, ax2 - ax1) * Math.max(0, ay2 - ay1);
+  const areaB = Math.max(0, bx2 - bx1) * Math.max(0, by2 - by1);
+  const ix1 = Math.max(ax1, bx1);
+  const iy1 = Math.max(ay1, by1);
+  const ix2 = Math.min(ax2, bx2);
+  const iy2 = Math.min(ay2, by2);
+  const inter = Math.max(0, ix2 - ix1) * Math.max(0, iy2 - iy1);
+  return inter / (areaA + areaB - inter + 1e-6);
+}
+
+async function detect(input) {
+  const model = await loadDetector();
+  const output = model.predict(input);
+  const [boxes, scores] = output;
+  const boxesArr = boxes.arraySync();
+  const scoresArr = scores.arraySync();
+  const keep = nms(boxesArr, scoresArr);
+  return keep.map(i => ({ box: boxesArr[i], score: scoresArr[i] }));
+}
+
+module.exports = { loadDetector, detect };

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.jsx';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/web/src/infer.js
+++ b/web/src/infer.js
@@ -1,0 +1,21 @@
+const { preprocess } = require('./preprocess.js');
+const { detect } = require('./detect.js');
+const { classify } = require('./classify.js');
+const { gradCAM } = require('./saliency.js');
+
+/**
+ * Run the full inference pipeline on an image element.
+ * @param {HTMLImageElement} img
+ * @returns {Promise<object>} results
+ */
+async function runInference(img) {
+  const input = preprocess(img);
+  const [detections, cls, heatmap] = await Promise.all([
+    detect(input),
+    classify(input),
+    gradCAM(input)
+  ]);
+  return { detections, cls, heatmap };
+}
+
+module.exports = { runInference };

--- a/web/src/preprocess.js
+++ b/web/src/preprocess.js
@@ -1,0 +1,21 @@
+const tf = require('@tensorflow/tfjs');
+
+/**
+ * Preprocess an image for model input.
+ * - Converts HTMLImageElement to tensor
+ * - Performs simple background removal
+ * - Resizes to 224x224 and normalizes
+ * @param {HTMLImageElement} img
+ * @returns {tf.Tensor4D}
+ */
+function preprocess(img) {
+  const tensor = tf.browser.fromPixels(img);
+  const resized = tf.image.resizeBilinear(tensor, [224, 224]);
+  const channels = tf.split(resized, 3, 2);
+  const mask = channels[1].greater(tf.scalar(10));
+  const filtered = resized.mul(mask);
+  const normalized = filtered.div(255);
+  return normalized.expandDims(0);
+}
+
+module.exports = { preprocess };

--- a/web/src/saliency.js
+++ b/web/src/saliency.js
@@ -1,0 +1,21 @@
+const tf = require('@tensorflow/tfjs');
+const { loadClassifier } = require('./classify.js');
+
+/**
+ * Compute a Grad-CAM saliency heatmap for the input image tensor.
+ * @param {tf.Tensor4D} input
+ * @returns {Promise<tf.Tensor3D>} heatmap
+ */
+async function gradCAM(input) {
+  const model = await loadClassifier();
+  const convLayer = model.layers[model.layers.length - 2];
+  const gradFunction = tf.grad(x => model.predict(x).max());
+  const grads = gradFunction(input, convLayer);
+  const pooled = tf.mean(grads, [0, 1, 2]);
+  const activation = convLayer.output.mul(pooled);
+  const heatmap = tf.relu(tf.sum(activation, -1));
+  const normalized = heatmap.div(tf.max(heatmap));
+  return normalized.squeeze();
+}
+
+module.exports = { gradCAM };


### PR DESCRIPTION
## Summary
- add web folder implementing basic React+TF.js inference modules
- include placeholder preprocess, detection, classification, saliency, and orchestration
- provide sample React UI and Jest test
- include README in models directory

## Testing
- `npm test --silent` within `web`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f16a0387483289104183c07ae22b8