### PR TITLE
Add mock hardware services

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,41 @@
 
 Smart Plant Monitoring and Automation System.
 
-## Camera Service
+## Services
 
-The `camera_service` captures images using OpenCV and analyzes foliage health. Based on the analysis it sends commands to the actuator service to adjust watering automatically.
+- **camera_service** - Captures images using OpenCV and analyses green foliage levels.
+- **plant_identifier_service** - Uses the Plant.id API to identify plants from images. Set `PLANT_ID_API_KEY` to use it.
+- **sensor_service** - Provides soil moisture readings via `/api/sensors`.
+- **actuator_service** - Receives watering commands via `/api/actuators`.
+- **automation_service** - Polls sensors and triggers actuators based on moisture and identification results.
 
-## Plant Identifier Service
+## Quick Start
 
-The `plant_identifier_service` uses the online Plant.id API to identify plant species from captured images. Set the `PLANT_ID_API_KEY` environment variable to use this service.
+1. Install Python dependencies:
 
-## Automation Service
+```bash
+pip install -r requirements.txt
+```
 
-The `automation_service` coordinates sensors, plant identification, and actuators to maintain optimal conditions.
+2. Start the mock hardware services in separate terminals:
+
+```bash
+python software/services/sensor_service/server.py
+python software/services/actuator_service/server.py
+```
+
+3. Run the automation controller:
+
+```bash
+PLANT_ID_API_KEY=your-key python software/services/automation_service/automation.py
+```
+
+4. (Optional) Run the web interface:
+
+```bash
+cd web
+npm install
+npm test
+```
+
+The automation service will periodically read moisture data and command the actuator service to turn watering on or off.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 opencv-python-headless
+flask

--- a/software/services/actuator_service/server.py
+++ b/software/services/actuator_service/server.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from flask import Flask, jsonify, request
+
+app = Flask(__name__)
+state = {"last_action": None}
+
+@app.post("/api/actuators")
+def command_actuator():
+    data = request.get_json(force=True)
+    action = data.get("action")
+    state["last_action"] = action
+    print("Actuator action:", action)
+    return jsonify({"status": "ok", "action": action})
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5001)

--- a/software/services/sensor_service/server.py
+++ b/software/services/sensor_service/server.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import random
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.get("/api/sensors")
+def get_sensors():
+    """Return mock sensor readings."""
+    moisture = random.uniform(0.0, 1.0)
+    return jsonify({"moisture": moisture})
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/tests/unit/test_actuator_service.py
+++ b/tests/unit/test_actuator_service.py
@@ -1,0 +1,16 @@
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from software.services.actuator_service.server import app
+
+
+def test_post_actuator():
+    client = app.test_client()
+    resp = client.post('/api/actuators', json={'action': 'water_on'})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['action'] == 'water_on'

--- a/tests/unit/test_sensor_service.py
+++ b/tests/unit/test_sensor_service.py
@@ -1,0 +1,17 @@
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from software.services.sensor_service.server import app
+
+
+def test_get_sensors():
+    client = app.test_client()
+    resp = client.get('/api/sensors')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'moisture' in data
+    assert 0.0 <= data['moisture'] <= 1.0


### PR DESCRIPTION
## Summary
- flesh out project readme with setup instructions
- add Flask-based sensor and actuator mock services
- add unit tests for the new services
- update requirements

## Testing
- `pytest -q`
- `npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f23be7d148328a3d15f8be8ea2779